### PR TITLE
Add enumerated enum field to schema properties

### DIFF
--- a/lib/resource/schema.js
+++ b/lib/resource/schema.js
@@ -52,6 +52,7 @@ Schema = new Class({
 					  , 'readonly' : !!field.options.readonly
 					  , 'help'     : field.options.help
 					  , 'unique'   : !!field.options.unique
+					  , 'enum'     : field.options.enum || []
 					};
 				})
 			};


### PR DESCRIPTION
One thing to note, `enum` is a reserved keyword (can't use it as a variable name). That shouldn't be a problem here, though.

In response to https://github.com/esatterwhite/tastypie-jsonschema/pull/2#issuecomment-218483886