### PR TITLE
Use parseInt to cast integers, not bitwise

### DIFF
--- a/lib/fields/integer.js
+++ b/lib/fields/integer.js
@@ -25,7 +25,7 @@ exports.IntegerField = IntegerField = new Class({
 	   help:'Converts values to Numbers with a base of 10'
 	}
 	,convert: function convert( value ){
-                return parseInt(value, 10);
+                return parseInt(value, 10) || 0;
 	}
 	,type: function( ){
 		return 'integer';

--- a/lib/fields/integer.js
+++ b/lib/fields/integer.js
@@ -25,7 +25,7 @@ exports.IntegerField = IntegerField = new Class({
 	   help:'Converts values to Numbers with a base of 10'
 	}
 	,convert: function convert( value ){
-                return parseInt(value, 10) || 0;
+                return parseInt(value, 10);
 	}
 	,type: function( ){
 		return 'integer';

--- a/lib/fields/integer.js
+++ b/lib/fields/integer.js
@@ -25,7 +25,7 @@ exports.IntegerField = IntegerField = new Class({
 	   help:'Converts values to Numbers with a base of 10'
 	}
 	,convert: function convert( value ){
-		return ~~value;
+                return parseInt(value, 10);
 	}
 	,type: function( ){
 		return 'integer';


### PR DESCRIPTION
Bitwise operators cast every input to a 32-bit (max 2^32) integer
(whereas JavaScript integer operators allow you to deal in integers up
to 2^53)

~~~js
~~2375120519 === -1919846777
// true
~~~

Ref: http://stackoverflow.com/a/12643063